### PR TITLE
Add dist to npm bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "types": "index.d.ts",
   "files": [
     "index.js",
-    "index.d.ts"
+    "index.d.ts",
+    "dist"
   ],
   "scripts": {
     "prepublish": "npm run test && npm run build",


### PR DESCRIPTION
Might want to bundle your `dist` folder in your npm bundle.

Using `unpkg` you can see the outcome of your `npm install` final build.

https://unpkg.com/grid-to-matrix/